### PR TITLE
Add worker docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM fedora:27
+
+ARG POLY_GIT=https://github.com/polyml/polyml.git
+ARG POLY_DIR=/polyml
+ARG OVEN_GIT=https://github.com/CakeML/regression.git
+ARG OVEN_DIR=/oven
+
+# basic stuff
+RUN dnf -y install gcc-c++ git curl make time
+
+# polyml
+RUN git clone ${POLY_GIT} ${POLY_DIR} && \
+    cd ${POLY_DIR} && \
+    ./configure && \
+    make && \
+    make install && \
+    cd / && \
+    rm -fr ${POLY_DIR}
+
+# cakeml-regression
+RUN git clone ${OVEN_GIT} ${OVEN_DIR} && \
+    cd ${OVEN_DIR} && \
+    sha1sum worker.sml > cakeml-token && \
+    uname -norm > name && \
+    polyc worker.sml -o worker
+
+
+WORKDIR ${OVEN_DIR}
+ENTRYPOINT ["/oven/worker"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Small library of useful code.
 
 [worker.sml](worker.sml):
 Worker that claims and runs regression test jobs.
+
+[Dockerfile](Dockerfile):
+Worker docker container for easy deployment `docker run -d agomezl/oven`.


### PR DESCRIPTION
This docker container allows to start a worker in any machine (with docker installed) by simply doing:
```
$ docker run -d --name oven1 agomezl/oven
``` 
You can check it's output with:
```
$ docker logs oven1
```
And stop it with:
```
$ docker stop oven1
$ docker rm oven1
```
The idea is to simplify the deployment of workers and allow for better control of resources using docker build-in cgroups functionality, eg:
```
$ docker run -d -m 16gb --name oven1 agomezl/oven
``` 
will limit the workers memory usage to 16gb, neat isn't?
