### PR TITLE
New interface for summary page

### DIFF
--- a/apiLib.sml
+++ b/apiLib.sml
@@ -252,6 +252,18 @@ fun read_job_type inp =
     else "master"
   end
 
+fun read_job_worker inp =
+  let
+    fun read_line () = Option.valOf (TextIO.inputLine inp)
+    fun loop () =
+        let val line = read_line ()
+        in if String.isPrefix "Machine: " line
+           then extract_prefix_trimr "Machine: " line
+           else loop ()
+        end
+  in loop ()
+  end
+
 fun read_secs timing =
   let
     val secs_millisecs = String.tokens (equal #".") timing

--- a/apiLib.sml
+++ b/apiLib.sml
@@ -254,14 +254,13 @@ fun read_job_type inp =
 
 fun read_job_worker inp =
   let
-    fun read_line () = Option.valOf (TextIO.inputLine inp)
-    fun loop () =
-        let val line = read_line ()
-        in if String.isPrefix "Machine: " line
-           then extract_prefix_trimr "Machine: " line
-           else loop ()
-        end
-  in loop ()
+    fun loop acc =
+        case TextIO.inputLine inp of
+            NONE      => acc
+         |  SOME line => if String.isPrefix "Machine: " line
+                         then extract_prefix_trimr "Machine: " line
+                         else loop acc
+  in loop "No worker"
   end
 
 fun read_secs timing =

--- a/regression-style.css
+++ b/regression-style.css
@@ -1,15 +1,22 @@
 h2, h3, h3 a, a:hover { color: #e80 }
 h2 { text-transform: capitalize; }
+h2 a { font-size: 18px; text-transform: none}
 h3 { font-size: 22px; }
+th { font-weight: normal}
 pre { font-size: 20px; }
 pre strong { display: block; margin-top: 1em; }
 pre time { font-size: 18px; }
 time.ago { font-size: 14px; }
-ul.jobs { list-style-type: none; font-size: 24px; padding-left: 1em; margin-top: 0em; }
-ul.jobs li { display: inline-block; padding-right: 2em; }
-ul.jobs li span { font-size: 18px; }
-ul.jobs li span.success { color: #0d0 }
-ul.jobs li span.failure { color: #d00 }
+table.jobs { font-size: 24px; padding-left: 1em; margin-top: 0em; border-spacing: 0em}
+table.jobs td  { border-bottom: 1px solid #ddd }
+table.jobs th  { border-bottom: 1px solid #777 }
+table.jobs tr th, table.jobs tr td { font-size: 18px; padding: 1em; padding-bottom: 0em}
+table.jobs tr span.success { color: #0d0 }
+table.jobs tr span.failure { color: #d00 }
+table.jobs tr span.nowrap { white-space: nowrap; }
+ul.jobs { font-size: 24px; padding-left: 1em; margin-top: 0em; }
+ul.jobs li { padding-right: 2em; }
+ul.jobs li span { font-size: 18px; padding-left: 1em}
 ul.jobs li span.nowrap { white-space: nowrap; }
 a { color: #337ab7; text-decoration: none; }
 a:hover { text-decoration: underline; }

--- a/regression-style.css
+++ b/regression-style.css
@@ -1,0 +1,17 @@
+h2, h3, h3 a, a:hover { color: #e80 }
+h2 { text-transform: capitalize; }
+h3 { font-size: 22px; }
+pre { font-size: 20px; }
+pre strong { display: block; margin-top: 1em; }
+pre time { font-size: 18px; }
+time.ago { font-size: 14px; }
+ul.jobs { list-style-type: none; font-size: 24px; padding-left: 1em; margin-top: 0em; }
+ul.jobs li { display: inline-block; padding-right: 2em; }
+ul.jobs li span { font-size: 18px; }
+ul.jobs li span.success { color: #0d0 }
+ul.jobs li span.failure { color: #d00 }
+ul.jobs li span.nowrap { white-space: nowrap; }
+a { color: #337ab7; text-decoration: none; }
+a:hover { text-decoration: underline; }
+footer { margin-top: 2em; }
+footer a { padding-right: 2em; }

--- a/server.sml
+++ b/server.sml
@@ -177,6 +177,8 @@ fun get_api () =
         Option.map (Api o G) (get_from_string (String.extract(path_info,4,NONE)))
       else if String.isPrefix "/job/" path_info then
         Option.map (Html o DisplayJob) (id_from_string (String.extract(path_info,5,NONE)))
+      else if String.isPrefix "/queue/" path_info then
+        SOME (Html (DisplayQueue (String.extract(path_info,7,NONE))))
       else if path_info = "/" then SOME (Html Overview)
       else cgi_die 404 [path_info," not found"]
   | (SOME path_info, SOME "POST") =>

--- a/serverLib.sml
+++ b/serverLib.sml
@@ -41,7 +41,7 @@ structure serverLib = struct
 
 open apiLib
 
-val content_type_text = "Content-Type:text/plain\n"
+val content_type_text = "Content-Type: text/plain\n"
 
 fun http_status 200 = ""
   | http_status 400 = "Status:400 Bad Request\n"
@@ -597,7 +597,7 @@ fun read_last_date inp =
         end handle Option => loop acc
   in loop NONE end
 
-val html_response_header = "Content-Type:text/html\n\n<!doctype html>"
+val html_response_header = "Content-Type: text/html\n\n<!doctype html>"
 
 val style_href = "/regression-style.css"
 

--- a/serverLib.sml
+++ b/serverLib.sml
@@ -701,8 +701,6 @@ in
 
   fun html_job_list n (q,ids) =
     if List.null ids then []
-    else if q = "running"
-    then [h2 q, table [("class","jobs")] [] (List.map (job_link q) ids)]
     else
       let
         val title = element "h2" [] [q," " ,a (String.concat[base_url,"/queue/",q]) "(all)"]

--- a/serverLib.sml
+++ b/serverLib.sml
@@ -647,8 +647,17 @@ structure HTML = struct
   fun status_attrs Success = [("class","success")]
     | status_attrs Failure = [("class","failure")]
     | status_attrs _ = []
+  val code = elt "code"
   val li = elt "li"
   fun ul attrs ls = element "ul" attrs (List.map li ls)
+  val td = elt "td"
+  val th = elt "th"
+  fun tr f attrs ls = element "tr" attrs (List.map f ls)
+  fun table attrs titles rows =
+      let
+        val t = tr th [] titles
+        val r = List.map (tr td []) rows
+      in element "table" attrs ( t :: r) end
   val footer = element "footer" []
 end
 

--- a/serverLib.sml
+++ b/serverLib.sml
@@ -661,7 +661,7 @@ structure HTML = struct
   val footer = element "footer" []
 end
 
-datatype html_request = Overview | DisplayJob of id
+datatype html_request = Overview | DisplayJob of id | DisplayQueue of string
 
 local
   open HTML
@@ -705,7 +705,7 @@ in
     then [h2 q, table [("class","jobs")] [] (List.map (job_link q) ids)]
     else
       let
-        val title = element "h2" [] [q," " ,a (String.concat[base_url,"/",q]) "(all)"]
+        val title = element "h2" [] [q," " ,a (String.concat[base_url,"/queue/",q]) "(all)"]
         val table_titles = ["job","type","time",code "HEAD","merge-base",code "HOL","worker"]
         val table_rows   = List.map (job_link q) (List.take (ids,n) handle _ => ids)
       in [title , table [("class","jobs")] table_titles table_rows]
@@ -890,6 +890,11 @@ in
       val s = file_to_string f
     in
       [a base_url "Overview", h3 (a jid (String.concat["Job ",jid])), pre (process jid s)]
+    end
+  | req_body (DisplayQueue q) =
+    let
+      val _ = cgi_assert (List.exists (equal q) queue_dirs) 500 ["Unknown queue: ", q]
+    in a base_url "Overview" :: html_job_list (~1) (q, read_list q ())
     end
 
   fun html_response req =


### PR DESCRIPTION
![2019-05-10-002835_777x948_scrot](https://user-images.githubusercontent.com/1539099/57490755-91f8dc80-72ba-11e9-9e38-264f7117cac7.png)

* A list of up-to 10 jobs are displayed in 3 categories (running,finished, aborted) just as before

* New paths `/queue/{running,finished,aborted}` to display the full list of jobs in each category

* CSS style was modified 

* Extra information was added on each job row (time,`HEAD`,merge-base,HOL commit, and worker)