### PR TITLE
misc worker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:latest
 
 ARG POLY_GIT=https://github.com/polyml/polyml.git
 ARG POLY_DIR=/polyml
@@ -6,24 +6,31 @@ ARG OVEN_GIT=https://github.com/CakeML/regression.git
 ARG OVEN_DIR=/oven
 
 # basic stuff
-RUN dnf -y install gcc-c++ git curl make time
+RUN dnf -y install gcc-c++ git curl make time psmisc diffutils && \
+    useradd -u 1050 -m oven && \
+    mkdir ${OVEN_DIR} && \
+    chown oven:oven ${OVEN_DIR}
 
 # polyml
 RUN git clone ${POLY_GIT} ${POLY_DIR} && \
     cd ${POLY_DIR} && \
+    git checkout v5.8.1 && \
     ./configure && \
     make && \
     make install && \
     cd / && \
     rm -fr ${POLY_DIR}
 
+# drop privileges
+USER oven
+
 # cakeml-regression
 RUN git clone ${OVEN_GIT} ${OVEN_DIR} && \
     cd ${OVEN_DIR} && \
     sha1sum worker.sml > cakeml-token && \
-    uname -norm > name && \
-    polyc worker.sml -o worker
-
+    polyc worker.sml -o worker && \
+    git config --global user.email oven && \
+    git config --global user.name oven
 
 WORKDIR ${OVEN_DIR}
-ENTRYPOINT ["/oven/worker"]
+ENTRYPOINT ["/bin/sh", "-c", "uname -norm > /oven/name && exec /oven/worker"]

--- a/README.md
+++ b/README.md
@@ -21,4 +21,18 @@ Small library of useful code.
 Worker that claims and runs regression test jobs.
 
 [Dockerfile](Dockerfile):
-Worker docker container for easy deployment `docker run -d agomezl/oven`.
+Worker docker container for easy deployment:
+
+    docker build -t oven .
+    # Unlimited RAM (only for dedicated machines w/ ample swap)
+    docker run -d --hostname=my-builder-name --name=container-name oven
+
+    # OR: Limit RAM to 70,000 MB
+    docker run -d --hostname=my-builder-name --name=container-name \
+        -e POLY_CLINE_OPTIONS="--maxheap 70000" oven
+
+    # Maintenance commands
+    docker exec container-name /oven/worker --help
+
+    # Skip 20 minute timeout after a refresh
+    docker exec container-name killall curl


### PR DESCRIPTION
* README tells people to build the container instead of using a 2 year old prebuilt
* Updated OS base
* Run builds as a normal user (and unlikely to match a host user)
* Pull hostname at container start time so that it can be set per-container
* Do git setup automatically
* Pin a polyml version (TBD if this is a working version, but we can change it later)