### PR TITLE
Check for proper prefix when sending slack msg

### DIFF
--- a/serverLib.sml
+++ b/serverLib.sml
@@ -384,7 +384,7 @@ structure Slack = struct
       val response = system_output (cgi_die 500) cmd
     in
       cgi_assert
-        (String.isPrefix "{\"ok\":true" response)
+        (String.isPrefix "ok" response)
         500 ["Error sending Slack message\n",response]
     end
 end


### PR DESCRIPTION
This is a quick fix for the prefix check in the `serverLib`. I forgot to adapt the validation check at the end to the new Slack API response which is just plain `ok`.