### PR TITLE
Set TERM to nothing when running Holmake

### DIFF
--- a/worker.sml
+++ b/worker.sml
@@ -323,7 +323,7 @@ in
       val root = OS.FileSys.getDir()
       val holdir = OS.Path.concat(root,HOLDIR)
       val holmake_cmd =
-        String.concat["HOLDIR='",holdir,"' /usr/bin/time ",time_options,
+        String.concat["TERM= HOLDIR='",holdir,"' /usr/bin/time ",time_options,
                       " '",holdir,"/bin/Holmake' --qof"]
       val cakemldir = OS.Path.concat(root,CAKEMLDIR)
       val () = OS.FileSys.chDir CAKEMLDIR


### PR DESCRIPTION
This is to prevent output from the Holmake command from containing ANSI escape codes.