### PR TITLE
Use 100-job average for expected times

### DIFF
--- a/serverLib.sml
+++ b/serverLib.sml
@@ -962,9 +962,9 @@ in
             (* val pad = CharVector.tabulate(max_dir_length - String.size dir,(fn _ => #" ")) *)
             val (l,r) = Substring.splitAt (Substring.full time_part,6)
             val files =
-              List.map (fn id => OS.Path.concat("running",Int.toString id)) (running()) @
               List.map (fn id => OS.Path.concat("finished",Int.toString id)) (finished())
-            val (t,fs) = timings_of_dir dir files
+            val recent_files = take 100 (List.rev files)
+            val (t,fs) = timings_of_dir dir recent_files
             val average = if List.null fs then [] else [" ",duration(Int.quot(t,List.length fs))]
             val line = String.concat [
               time_part, prefix, dir, " ",

--- a/utilLib.sml
+++ b/utilLib.sml
@@ -13,6 +13,9 @@ structure utilLib = struct
       if x >= y then x::y::xs
       else y::(insert x xs)
 
+  fun take n [] = []
+    | take n (x::xs) = if n <= 0 then [] else x :: take (n - 1) xs;
+
   val until_space =
     Substring.string o Substring.takel (not o Char.isSpace) o Substring.full
 


### PR DESCRIPTION
Recently CakeML regression times have changed significantly, due to build sequence edits and usage of `cv_compute`. As a result, the expected/average times displayed on the webpage are quite inaccurate. This PR attempts to improve the situation by using a 100-job moving average to calculate these times, instead of an all-job average.