### PR TITLE
Add Arm tarball to release command

### DIFF
--- a/serverLib.sml
+++ b/serverLib.sml
@@ -564,7 +564,7 @@ structure GitHub = struct
         cakeml_upload_endpoint github_id asset]
     end
 
-  val assets = ["cake-x64-64.tar.gz", "cake-x64-32.tar.gz"]
+  val assets = ["cake-x64-64.tar.gz", "cake-x64-32.tar.gz", "cake-arm8-64.tar.gz"]
 
   fun get_github_id id =
     let open ReadJSON


### PR DESCRIPTION
Following https://github.com/CakeML/cakeml/pull/1022 and an update to the artefacts uploaded during regression (https://github.com/CakeML/cakeml/commit/6eebd384c0cb34314a58957d79a6489087db8721), we can add the Arm8 tarball to the automatic release mechanism.