### PR TITLE
Use "embeds" for Discord messages

### DIFF
--- a/server.sml
+++ b/server.sml
@@ -123,8 +123,9 @@ fun finish id =
     val hol_sha = get_hol_sha snapshot
     val status = read_status inp
     val inp = (TextIO.closeIn inp; TextIO.openIn new)
+    val job_pr = read_job_pr inp
     val branch =
-      case read_job_pr inp of
+      case job_pr of
         NONE => "master"
       | SOME (_, branch) => Substring.string (trim_ws branch)
     val subject = String.concat[status_to_string status,": Job ",f," ",branch]
@@ -135,7 +136,7 @@ fun finish id =
     Posix.IO.close fd;
     GitHub.set_status f cakeml_sha status;
     Slack.send_message message;
-    Discord.send_message message;
+    Discord.send_message (Discord.compose_message f status job_pr);
     send_email subject (String.concat[body,"\n"]);
     ()
   end


### PR DESCRIPTION
This PR uses Discord's "embeds" to add some markup to the regression notifications which appear on the CakeML Discord. In particular, it aims to produce notifications like the ones below, where the title links to the job page and the PR number links to the GitHub PR page.

<img width="241" alt="image" src="https://github.com/user-attachments/assets/da5460e7-bc4e-4af8-bac1-f1e1d4b0b729">

The output of an example `compose_message` was tested on https://leovoel.github.io/embed-visualizer/.