### PR TITLE
Fix bug in Discord embeds

### DIFF
--- a/serverLib.sml
+++ b/serverLib.sml
@@ -644,6 +644,7 @@ structure Discord = struct
         | SOME (pr, branch) =>
             String.concatWith " " ["Pull request", pr_md_link (Substring.string pr),
                                    Substring.string (trim_ws branch)]
+      val description = String.translate (fn c => if c = #"\"" then "&quot;" else String.str c) description
     in
       String.concat [
         "{\"embeds\": [{",
@@ -657,7 +658,6 @@ structure Discord = struct
 
   fun send_message text =
     let
-      val text = String.translate (fn c => if c = #"\"" then "&quot;" else String.str c) text
       val cmd = postMessage_curl_cmd text
       val response = system_output (cgi_die 500) cmd
     in


### PR DESCRIPTION
Should fix an issue in PR https://github.com/CakeML/regression/pull/33. In particular, that PR changed the way a JSON was constructed and passed to `curl`, but failed to update the escaping of quotation marks. This resulted in too many quotation marks being escaped, producing a corrupted JSON. This commit ensures that only quotation marks *within* a JSON field are escaped, not the quotation marks that delimit JSON fields.