### PR TITLE
Fix server dying on sending Zulip message

### DIFF
--- a/serverLib.sml
+++ b/serverLib.sml
@@ -711,9 +711,12 @@ structure Zulip = struct
     let
       val cmd = postMessage_curl_cmd text
       val response = system_output (cgi_die 500) cmd
+      val response_lines = String.tokens (fn x => x = #"\n") response
     in
       cgi_assert
-        (String.isPrefix "204" response)
+        (List.exists (String.isPrefix "204") response_lines orelse
+         List.exists (String.isPrefix "200") response_lines
+        )
         500 ["Error sending Zulip message\n",response]
     end
 end


### PR DESCRIPTION
The server code prior to this commit appears to expect a `204` No Content response when successfully sending a Zulip message, but the response Zulip gives is often (always?) a `200` OK instead. Thus the server interprets successful sends as a failures, and propagates this failure to the worker. The worker then aborts, since instead of receiving the expected `Finished` response to the API call that triggered the Zulip message, it gets something like this:

```
Error:
Error sending Zulip message
{"result":"success","msg":"","id":521754098}
200
```

...where the last two lines are what the server received from Zulip.

I have not tested this commit beyond compiling it, since I do not run a regression server; I hope @xrchz can do this.

For the same reason, the generalised "204 or 200" check is written in a way that is arguably a bit generous in what it accepts.

One could also argue that there's no reason for the server to crash the worker when a Zulip message failed to send, since this is not a worker concern at all. If so, there's an even simpler fix: just remove the assert entirely.